### PR TITLE
Update bucky.rb

### DIFF
--- a/Formula/bucky.rb
+++ b/Formula/bucky.rb
@@ -16,7 +16,7 @@ class Bucky < Formula
   end
 
   def caveats
-    <<-EOS.undent
+    <<~EOS
       The manual, examples, and scripts are installed to:
           #{pkgshare}
     EOS


### PR DESCRIPTION
==> Downloading http://www.stat.wisc.edu/~ane/bucky/v1.4/bucky-1.4.4.tgz
==> make
Error: Calling <<-EOS.undent is disabled!
Use <<~EOS instead.
/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/jonchang/homebrew-biology/Formula/bucky.rb:22:in `caveats'
Please report this to the jonchang/biology tap!
Or, even better, submit a PR to fix it!